### PR TITLE
[joss][chore] Remove unused and old code :)

### DIFF
--- a/thresholdmann-worker.js
+++ b/thresholdmann-worker.js
@@ -1,19 +1,3 @@
-// const interpolation = (pos, points, values) => {
-//   let val = 0;
-//   let totalw = 0;
-//   for (let k=0; k<points.length; k++) {
-//     const d =
-//       (pos[0] - points[k][0]) ** 2 +
-//       (pos[1] - points[k][1]) ** 2 +
-//       (pos[2] - points[k][2]) ** 2;
-//     const w = 1 / (d + 0.001);
-//     val += w * values[k];
-//     totalw += w;
-//   }
-
-//   return val / totalw;
-// };
-
 const interpolation = (pos, points, values) => {
   const backgroundValue = 255;
   const wBackground = 0.00001;

--- a/thresholdmann.js
+++ b/thresholdmann.js
@@ -493,36 +493,6 @@ const saveMask = () => {
   thresholdJob();
 };
 
-/** Save the selection mask produced by the
- * threshold, but in the main thread.
- * @deprecated
- * @returns {void}
- */
-// eslint-disable-next-line no-unused-vars
-const saveMaskOLD = () => {
-  const {mv, interpolate} = globals;
-  const [dim] = mv.mri;
-  const data = new Float32Array(dim[0] * dim[1] * dim[2]);
-  let val;
-  let i, j, k;
-  let ijk;
-  for (i = 0; i < dim[0]; i++) {
-    for (j = 0; j < dim[1]; j++) {
-      for (k = 0; k < dim[2]; k++) {
-        ijk = k * dim[1] * dim[0] + j * dim[0] + i;
-        val = interpolate([i, j, k]) * mv.maxValue / 255;
-
-        if (mv.mri.data[ijk] <= val) {
-          data[ijk] = 0;
-        } else {
-          data[ijk] = 1;
-        }
-      }
-    }
-  }
-  saveNifti(data);
-};
-
 const saveControlPoints = () => {
   const a = document.createElement('a');
   const {points, values} = globals;


### PR DESCRIPTION
Part of: https://github.com/openjournals/joss-reviews/issues/6336

quick chore, saw there was an unused function marked `OLD` and a commented out function, so here's taking those out :)

There is still a duplicated definition of `interpolation` in `thresholdmann-worker.js` and `thresholdmann.js` , but since this is vanilla JS where relying on global definition can be sorta sketch that's fine.