### PR TITLE
[joss] fix incomplete attribute selectors in keyboard shortcuts

### DIFF
--- a/thresholdmann.js
+++ b/thresholdmann.js
@@ -626,22 +626,22 @@ const initKeyboardShortcuts = () => {
     case 's':
       globals.selectedTool = 'Select';
       document.querySelector('#tools').querySelector('.mui-pressed').classList.remove('mui-pressed');
-      document.querySelector('#tools').querySelector('[title="Select"').classList.add('mui-pressed');
+      document.querySelector('#tools').querySelector('[title="Select"]').classList.add('mui-pressed');
       break;
     case 'a':
       globals.selectedTool = 'Add';
       document.querySelector('#tools').querySelector('.mui-pressed').classList.remove('mui-pressed');
-      document.querySelector('#tools').querySelector('[title="Add"').classList.add('mui-pressed');
+      document.querySelector('#tools').querySelector('[title="Add"]').classList.add('mui-pressed');
       break;
     case 'r':
       globals.selectedTool = 'Remove';
       document.querySelector('#tools').querySelector('.mui-pressed').classList.remove('mui-pressed');
-      document.querySelector('#tools').querySelector('[title="Remove"').classList.add('mui-pressed');
+      document.querySelector('#tools').querySelector('[title="Remove"]').classList.add('mui-pressed');
       break;
     case 'm':
       globals.selectedTool = 'Move';
       document.querySelector('#tools').querySelector('.mui-pressed').classList.remove('mui-pressed');
-      document.querySelector('#tools').querySelector('[title="Move"').classList.add('mui-pressed');
+      document.querySelector('#tools').querySelector('[title="Move"]').classList.add('mui-pressed');
       break;
     }
   });


### PR DESCRIPTION
Part of: https://github.com/openjournals/joss-reviews/issues/6336

The keyboard shortcuts currently use incomplete attribute selectors, eg.

`querySelector('[title="Select"')`

These work, but they [shouldn't](https://www.w3.org/TR/selectors-3/#Conformance) since i think all levels of the CSS spec say browsers should ignore invalid selectors. 

In any case, my linter is yelling at these being incomplete, so here's a function-neutral PR to make it be quiet.